### PR TITLE
clarify that oqs is needed for these certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ A Repository to hold example x509 objects with PQ-Safe Algorithms
 
 
 The x509 Objects (certs/csrs/ocsp/ctl) in this repo were created using the OQS Provider
-https://github.com/open-quantum-safe/oqs-provider from the Open Quantum Safe project
+https://github.com/open-quantum-safe/oqs-provider from the Open Quantum Safe project.
 
 This, however, means that these x509 objects will be parseable with standard OpenSSL or other x509 clients
-which haven't been updated to recognise the PQ-Safe algorithms
+which haven't been updated to recognise the PQ-Safe algorithms.
 
 Currently they are using dilitium2/3, however as per FIPS-204 internet draft, they will need to be updated
-to the revised ML-DSA-44/64 OIDS when they have been confirmed
+to the revised ML-DSA-44/64 OIDS when they have been confirmed.
 https://csrc.nist.gov/pubs/fips/204/ipd

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Repository to hold example x509 objects with PQ-Safe Algorithms
 The x509 Objects (certs/csrs/ocsp/ctl) in this repo were created using the OQS Provider
 https://github.com/open-quantum-safe/oqs-provider from the Open Quantum Safe project.
 
-This, however, means that these x509 objects will be parseable with standard OpenSSL or other x509 clients
+This, however, means that these x509 objects will not be parseable with standard OpenSSL or other x509 clients
 which haven't been updated to recognise the PQ-Safe algorithms.
 
 Currently they are using dilitium2/3, however as per FIPS-204 internet draft, they will need to be updated


### PR DESCRIPTION
The README erroneously stated that these certs would be readable by vanilla OpenSSL; I'm quite sure the intent was to note that vanilla OpenSSL can *not* read them:

```
<cert openssl x509 -pubkey -noout | more
Warning: Reading certificate from stdin since no -in or -new option is given
Error getting public key
C03ADB0202000000:error:03000072:digital envelope routines:X509_PUBKEY_get0:decode error:crypto/x509/x_pubkey.c:464:
```